### PR TITLE
Filter out pre-release versions from fetched Haqq releases

### DIFF
--- a/nix/packages/haqq/update.sh
+++ b/nix/packages/haqq/update.sh
@@ -44,7 +44,7 @@ while read -r obj; do
         '{ $version: { url: $url, hash: $hash } }'
     )"
   )
-done < <(jq -c '.[]' <<<"$result")
+done < <(jq -c '.[] | select(.prerelease | not)' <<<"$result")
 
 dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 jq --slurp 'add' <<<"${versions[*]}" >"$dir/versions.json"


### PR DESCRIPTION
### 🔧 Filter out pre-release versions from fetched Haqq releases

This pull request updates the script to ignore **pre-release** versions when fetching Haqq release metadata from GitHub.

#### ✅ Changes made:

* Updated the `jq` filter in the release-fetching loop to exclude releases where `.prerelease == true`.
* Now the script processes only **stable** (non-pre-release) versions.
* This ensures that `versions.json` only includes production-ready release assets.

#### 💡 Motivation:

Including pre-releases in the version list may lead to broken or untested builds. Filtering them out ensures that only verified stable binaries are downloaded and used, which improves reliability of downstream Nix builds or automation processes.

#### 📎 Related code snippet:

```bash
# Before
jq -c '.[]' <<<"$result"

# After
jq -c '.[] | select(.prerelease | not)' <<<"$result"
```