### PR TITLE
fix: Fetch up to 100 releases from GitHub API

### DIFF
--- a/nix/packages/haqq/update.sh
+++ b/nix/packages/haqq/update.sh
@@ -25,7 +25,7 @@ get_hash() {
     "$(nix-prefetch-url --type "$type" "$1")"
 }
 
-api="https://api.github.com/repos/haqq-network/haqq/releases"
+api="https://api.github.com/repos/haqq-network/haqq/releases?per_page=100"
 result="$(curl --fail -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "$api")"
 
 declare -a versions


### PR DESCRIPTION
This PR updates the GitHub API request to include the `?per_page=100` parameter, ensuring that up to 100 release versions are retrieved instead of the default 30. This resolves the issue where the latest releases were missing from `versions.json`.

No other logic is changed. If the number of releases ever exceeds 100, we should consider adding pagination support.